### PR TITLE
Add ClickUp integration

### DIFF
--- a/.github/workflows/clickup.yml
+++ b/.github/workflows/clickup.yml
@@ -1,0 +1,16 @@
+# .github/workflows/clickup.yml
+name: ClickUp Integration
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, review_requested]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  clickup:
+    uses: CodePilotSE/infra-scripts/.github/workflows/clickup-integration.yml@main
+    permissions:
+      contents: write
+      pull-requests: read
+    secrets: inherit


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to integrate ClickUp with the repository. The workflow is triggered by various pull request and review events and leverages a shared workflow for the integration.

**CI/CD and workflow automation:**

* Added `.github/workflows/clickup.yml` to automate ClickUp integration, triggering on pull request and review events, and delegating to a shared workflow (`clickup-integration.yml`).